### PR TITLE
Update ng2-izitoast.es5.js

### DIFF
--- a/ng2-izitoast.es5.js
+++ b/ng2-izitoast.es5.js
@@ -151,7 +151,7 @@ var Ng2IzitoastService = (function () {
     function (iziToastClass, options) {
         if (options === void 0) { options = null; }
         var /** @type {?} */ toast = document.querySelector(iziToastClass);
-        iziToast.hide(toast, options);
+        iziToast.hide(options, toast);
     };
     /**
      * @return {?}


### PR DESCRIPTION
- Changed argument order when  calling the `hide` function to match the signature of the iziToast library